### PR TITLE
CI: Make space before installing all backends

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - name: Clean up space
+        run: |
+          sudo rm -rf "/opt/ghc" || true
+          sudo rm -rf "/usr/share/dotnet" || true
+          sudo rm -rf "/usr/local/lib/android" || true
+          sudo rm -rf "/usr/local/share/boost" || true
       - name: Python info
         shell: bash -e {0}
         run: |


### PR DESCRIPTION
(Hopefully) avoids OOM failures of CI jobs for mypy by removing some software from the image before installing the package with all backends.
See
- https://github.com/actions/runner-images/issues/709
- https://github.com/actions/runner-images/issues/2840

I followed one of the linked PRs there, in particular: https://github.com/future-architect/vuls/pull/1957/files 