### PR TITLE
Move kernel definition for nb_kernel to `conf.py`

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -34,9 +34,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools
           pip install .[dev,tensorflow]
-      - name: Install kernel for notebooks
-        run: |
-          python -m ipykernel install --user --name python312 --display-name "Python 3.12"
       - name: Build documentation
         run: |
           cd docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,3 +103,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "pandas": ("http://pandas.pydata.org/docs/", None),
 }
+
+# -- Options for myst-nb
+
+nb_kernel_rgx_aliases = {"python312": "python3"}


### PR DESCRIPTION
This makes it easier to build docs also locally. See https://myst-nb.readthedocs.io/en/latest/computation/execute.html#execute-with-a-different-kernel-name, found with Gemini.