### PR TITLE
Add docs check

### DIFF
--- a/.github/actions/setup-python-cached/action.yml
+++ b/.github/actions/setup-python-cached/action.yml
@@ -1,0 +1,35 @@
+name: Set up Python with pip caching
+description: Set up Python, cache pip packages, and install dependencies
+
+inputs:
+  python-version:
+    description: Python version to install
+    required: true
+  extras:
+    description: Comma-separated pip extras to install (e.g. "dev,tensorflow")
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Python info
+      shell: bash -e {0}
+      run: |
+        which python
+        python --version
+    - name: Cache pip packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ inputs.python-version }}-
+    - name: Upgrade pip and install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install .[${{ inputs.extras }}]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,19 +20,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-python-cached
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Python info
-        shell: bash -e {0}
-        run: |
-          which python
-          python --version
-      - name: Upgrade pip and install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install .[dev,publishing,tensorflow]
+          extras: dev,publishing,tensorflow
       - name: Run unit tests
         run: python -m pytest -v
         env:
@@ -46,19 +37,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-python-cached
         with:
-          python-version: 3.12
-      - name: Python info
-        shell: bash -e {0}
-        run: |
-          which python
-          python --version
-      - name: Upgrade pip and install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install .[dev,publishing]
+          python-version: '3.12'
+          extras: dev,publishing
       - name: Check style against standards using ruff
         run: |
           ruff check
@@ -72,19 +54,10 @@ jobs:
         backend: ['tensorflow', 'torch', 'jax']
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-python-cached
         with:
           python-version: '3.12'
-      - name: Python info
-        shell: bash -e {0}
-        run: |
-          which python
-          python --version
-      - name: Upgrade pip and install dependencies with backend ${{ matrix.backend }}
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install .[dev,publishing,${{ matrix.backend }}]
+          extras: dev,publishing,${{ matrix.backend }}
       - name: Run unit tests
         run: python -m pytest -v
         env:
@@ -96,24 +69,15 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
       - name: Clean up space
         run: |
           sudo rm -rf "/opt/ghc" || true
           sudo rm -rf "/usr/share/dotnet" || true
           sudo rm -rf "/usr/local/lib/android" || true
           sudo rm -rf "/usr/local/share/boost" || true
-      - name: Python info
-        shell: bash -e {0}
-        run: |
-          which python
-          python --version
-      - name: Upgrade pip and install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          python -m pip install .[dev,publishing,tensorflow,torch,jax]
+      - uses: ./.github/actions/setup-python-cached
+        with:
+          python-version: '3.12'
+          extras: dev,publishing,tensorflow,torch,jax
       - name: Run mypy on package
         run: mypy src/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,19 +21,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ffmpeg
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-python-cached
         with:
-          python-version: 3.12
-      - name: Python info
-        shell: bash -e {0}
-        run: |
-          which python
-          python --version
-      - name: Upgrade pip and install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools
-          pip install .[dev,tensorflow]
+          python-version: '3.12'
+          extras: dev,tensorflow
+      - name: Cache jupyter-cache
+        uses: actions/cache@v4
+        with:
+          path: docs/_build/.jupyter_cache
+          key: ${{ runner.os }}-jupyter-cache-${{ hashFiles('docs/tutorials/**') }}
+          restore-keys: |
+            ${{ runner.os }}-jupyter-cache-
       - name: Build documentation
         run: |
           cd docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,7 @@ myst_enable_extensions = [
 nb_merge_streams = True
 nb_execution_mode = "cache"
 nb_execution_timeout = 120
+nb_execution_raise_on_error = True
 nb_scroll_outputs = True
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/tutorials/simple_prf_simulated.md
+++ b/docs/tutorials/simple_prf_simulated.md
@@ -184,7 +184,7 @@ grid_fitter = GridFitter(
 grid_history, grid_params = grid_fitter.fit(
     data=simulated_response,
     parameter_values=param_ranges,
-    chunk_size=20,
+    batch_size=20,
 )
 ```
 

--- a/src/prfmodel/models/impulse/two_gamma_deriv.py
+++ b/src/prfmodel/models/impulse/two_gamma_deriv.py
@@ -46,11 +46,11 @@ class DerivativeTwoGammaImpulse(BaseImpulse):
 
     .. math::
 
-        f(t) = f_{\text{gamma_diff}}(t) - \tau f'_{\text{gamma_diff}}(t)
+        f(t) = f_{\text{diff}}(t) - \tau f'_{\text{diff}}(t)
 
     .. math::
 
-        f_{\text{gamma_diff}}(t) = f_{\text{gamma}}(t; \alpha_1, \lambda_1) - \omega
+        f_{\text{diff}}(t) = f_{\text{gamma}}(t; \alpha_1, \lambda_1) - \omega
             f_{\text{gamma}}(t; \alpha_2, \lambda_2)
 
     Positive `weight_deriv` values shift the response to the right.


### PR DESCRIPTION
Currently, the documentation GitHub action does not fail when the tutorial/example notebooks fail during execution. This makes it hard to detect when code changes break them.

This PR changes the behavior of Sphinx to fail with an error if any notebooks (or MyST Markdown files) fail to execute.

Also adds caching for pip installs in all workflows and for notebooks.

Adds a custom GitHub action that bundles the Python setup, pip caching, and package installation.