### PR TITLE
Add docs deployment for multiple branches

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,12 @@ name: documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build and deploy docs for (leave empty to deploy main)'
+        required: false
+        default: ''
+        type: string
   push:
     branches:
     - main
@@ -17,6 +23,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch != '' && github.event.inputs.branch || github.ref }}
+      - name: Determine deployment target
+        id: deploy-target
+        run: |
+          BRANCH="${{ github.event.inputs.branch }}"
+          if [[ -z "$BRANCH" || "$BRANCH" == "main" ]]; then
+            echo "dir=." >> "$GITHUB_OUTPUT"
+          else
+            SAFE=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            echo "dir=branches/${SAFE}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install ffmpeg
         run: |
           sudo apt-get update
@@ -40,7 +58,8 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
         with:
-          publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
           publish_dir: docs/_build/html/
-          force_orphan: true
+          destination_dir: ${{ steps.deploy-target.outputs.dir }}
+          keep_files: true


### PR DESCRIPTION
Adds an option to deploy the docs website for multiple branches simultaneously. Currently, there are only two options: Deploy from main OR deploy from a target branch overwriting the currently deployment from main. This changes the workflow to allow both in parallel.