### PR TITLE
89 compare with existing packages

### DIFF
--- a/.github/workflows/validate-packages.yml
+++ b/.github/workflows/validate-packages.yml
@@ -1,0 +1,69 @@
+name: Validate external pRF packages
+
+# Run manually from the Actions tab.
+# Choose which external package and which model to compare against prfmodel.
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the validations from (leave empty to deploy main)'
+        required: false
+        default: ''
+        type: string
+      package:
+        description: 'External package to compare against prfmodel'
+        required: true
+        default: 'prfpy'
+        type: choice
+        options:
+          - prfpy
+          - braincoder
+      model:
+        description: 'pRF model to validate (only gaussian-2d supported for now)'
+        required: true
+        default: 'gaussian-2d'
+        type: choice
+        options:
+          - gaussian-2d
+
+jobs:
+  validate:
+    name: Validate ${{ inputs.model }} pRF against ${{ inputs.package }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-3.12-validate-${{ inputs.package }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-3.12-validate-${{ inputs.package }}-
+
+      - name: Install prfmodel
+        run: pip install -e .[tensorflow]
+
+      # Package-specific installs
+      - name: Install prfpy
+        if: inputs.package == 'prfpy'
+        run: pip install git+https://github.com/VU-Cog-Sci/prfpy.git
+
+      - name: Install braincoder (+ TensorFlow backend it requires)
+        if: inputs.package == 'braincoder'
+        run: |
+          pip install tensorflow "tensorflow-probability[tf]"
+          pip install git+https://github.com/Gilles86/braincoder.git
+
+      - name: Run validation
+        run: python validation/compare_${{ inputs.package }}.py
+        env:
+          KERAS_BACKEND: tensorflow

--- a/.github/workflows/validate-packages.yml
+++ b/.github/workflows/validate-packages.yml
@@ -36,21 +36,10 @@ jobs:
         with:
           ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+     - uses: ./.github/actions/setup-python-cached
         with:
           python-version: '3.12'
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-3.12-validate-${{ inputs.package }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-3.12-validate-${{ inputs.package }}-
-
-      - name: Install prfmodel
-        run: pip install -e .[tensorflow]
+          extras: tensorflow
 
       # Package-specific installs
       - name: Install prfpy

--- a/.github/workflows/validate-packages.yml
+++ b/.github/workflows/validate-packages.yml
@@ -35,8 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch != '' && inputs.branch || github.ref }}
-
-     - uses: ./.github/actions/setup-python-cached
+      - uses: ./.github/actions/setup-python-cached
         with:
           python-version: '3.12'
           extras: tensorflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,12 @@ pydocstyle.convention = "numpy"
     "INP001", # Part of implicit namespace package
     "A001", # Variable `copyright` is shadowing Python builtin. See https://github.com/sphinx-doc/sphinx/issues/8132
 ]
+"validation/**.py" = [
+    "ANN",   # Type annotations not required in validation scripts
+    "T201",  # print() is intentional for script output
+    "D103",  # Docstrings not required for script-level main()
+    "E402",  # sys.path/backend setup must precede local imports
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["prfmodel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,6 @@ pydocstyle.convention = "numpy"
     "A001", # Variable `copyright` is shadowing Python builtin. See https://github.com/sphinx-doc/sphinx/issues/8132
 ]
 "validation/**.py" = [
-    "ANN",   # Type annotations not required in validation scripts
     "T201",  # print() is intentional for script output
     "D103",  # Docstrings not required for script-level main()
     "E402",  # sys.path/backend setup must precede local imports

--- a/validation/compare_braincoder.py
+++ b/validation/compare_braincoder.py
@@ -1,0 +1,103 @@
+"""Validate prfmodel's 2D Gaussian pRF against braincoder.
+
+Comparison strategy
+-------------------
+We compare the pre-HRF neural response: the dot product of the Gaussian RF
+with the stimulus design matrix.
+
+HRF comparison is not possible with braincoder: GaussianPRF2D has no HRF
+convolution option, so the only meaningful cross-package check is the spatial
+encoding step.
+
+- prfmodel: Gaussian2DPRFModel(impulse_model=None, temporal_model=None)
+- braincoder: GaussianPRF2D.predict() - this class has no HRF convolution option,
+  so it matches prfmodel's no-HRF setup.
+
+Coordinate conventions
+----------------------
+prfmodel stimulus grid: shape (H, W, 2), last axis = [y, x] in visual-angle degrees.
+braincoder GaussianPRF2D:
+  - paradigm: (n_timepoints, H, W) - same layout as prfmodel's design
+  - grid_coordinates: DataFrame with columns ['x', 'y'] in visual-angle degrees,
+    one row per spatial pixel (H*W rows total, row-major / C order)
+  - parameters: DataFrame with columns ['x', 'y', 'sd', 'amplitude', 'baseline']
+    where 'x'/'y' are the RF centre and 'sd' is sigma
+
+Installation
+------------
+pip install git+https://github.com/Gilles86/braincoder.git
+(requires tensorflow and tensorflow-probability)
+"""
+
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+try:
+    import tensorflow as tf
+    from braincoder.models import GaussianPRF2D
+except ImportError:
+    print(
+        "ERROR: braincoder is not installed.\n"
+        "Install with: pip install git+https://github.com/Gilles86/braincoder.git\n"
+        "Note: braincoder requires tensorflow and tensorflow-probability.",
+    )
+    sys.exit(1)
+
+# Force float32 globally so all TF operations use a consistent dtype.
+tf.keras.backend.set_floatx("float32")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from shared import AMPLITUDE
+from shared import MU_X
+from shared import MU_Y
+from shared import SIGMA
+from shared import check_and_exit
+from shared import load_stimulus
+from shared import make_params
+from shared import prfmodel_response
+
+
+def _braincoder_response(stimulus) -> np.ndarray:
+    """Compute pre-HRF response using braincoder's GaussianPRF2D.
+
+    Returns a 1-D array of length n_frames.
+    """
+    # prfmodel grid: (H, W, 2) with [:,:,0]=y, [:,:,1]=x.
+    # braincoder expects rows=pixels, columns=['x', 'y'].
+    grid_flat = stimulus.grid.reshape(-1, 2)  # (H*W, 2)
+    grid_coordinates = pd.DataFrame(
+        {"x": grid_flat[:, 1], "y": grid_flat[:, 0]},  # swap [y, x] -> [x, y]
+    ).astype("float32")
+
+    bc_params = pd.DataFrame(
+        {
+            "x": [MU_X],
+            "y": [MU_Y],
+            "sd": [SIGMA],
+            "amplitude": [AMPLITUDE],
+            "baseline": [0.0],  # no baseline: matches prfmodel with temporal_model=None
+        },
+    ).astype("float32")
+
+    model = GaussianPRF2D(
+        paradigm=stimulus.design.astype("float32"),
+        grid_coordinates=grid_coordinates,
+    )
+    prediction = model.predict(parameters=bc_params)  # DataFrame (T, 1)
+
+    return np.asarray(prediction).ravel()
+
+
+def main() -> None:
+    """Run braincoder comparison and exit with 0 on pass, 1 on fail."""
+    stimulus = load_stimulus()
+    params = make_params()
+    ref = prfmodel_response(stimulus, params, with_hrf=False)
+    bc = _braincoder_response(stimulus)
+    check_and_exit(ref, bc, "braincoder")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/compare_braincoder.py
+++ b/validation/compare_braincoder.py
@@ -13,6 +13,11 @@ encoding step.
 - braincoder: GaussianPRF2D.predict() - this class has no HRF convolution option,
   so it matches prfmodel's no-HRF setup.
 
+--- Changes in this commit ---
+check_and_exit now returns bool instead of calling sys.exit (see shared.py).
+main() captures the return value and calls sys.exit explicitly at the end.
+Behaviour is identical to before.
+
 Coordinate conventions
 ----------------------
 prfmodel stimulus grid: shape (H, W, 2), last axis = [y, x] in visual-angle degrees.
@@ -96,7 +101,8 @@ def main() -> None:
     params = make_params()
     ref = prfmodel_response(stimulus, params, with_hrf=False)
     bc = _braincoder_response(stimulus)
-    check_and_exit(ref, bc, "braincoder")
+    passed = check_and_exit(ref, bc, "braincoder (pre-HRF)")
+    sys.exit(0 if passed else 1)
 
 
 if __name__ == "__main__":

--- a/validation/compare_braincoder.py
+++ b/validation/compare_braincoder.py
@@ -13,11 +13,6 @@ encoding step.
 - braincoder: GaussianPRF2D.predict() - this class has no HRF convolution option,
   so it matches prfmodel's no-HRF setup.
 
---- Changes in this commit ---
-check_and_exit now returns bool instead of calling sys.exit (see shared.py).
-main() captures the return value and calls sys.exit explicitly at the end.
-Behaviour is identical to before.
-
 Coordinate conventions
 ----------------------
 prfmodel stimulus grid: shape (H, W, 2), last axis = [y, x] in visual-angle degrees.
@@ -54,17 +49,15 @@ except ImportError:
 tf.keras.backend.set_floatx("float32")
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from shared import AMPLITUDE
-from shared import MU_X
-from shared import MU_Y
-from shared import SIGMA
-from shared import check_and_exit
+from shared import BASE_MODEL_PARAMS
+from shared import PRFStimulus
+from shared import compare_predictions
 from shared import load_stimulus
 from shared import make_params
 from shared import prfmodel_response
 
 
-def _braincoder_response(stimulus) -> np.ndarray:
+def _braincoder_response(stimulus: PRFStimulus) -> np.ndarray:
     """Compute pre-HRF response using braincoder's GaussianPRF2D.
 
     Returns a 1-D array of length n_frames.
@@ -78,10 +71,10 @@ def _braincoder_response(stimulus) -> np.ndarray:
 
     bc_params = pd.DataFrame(
         {
-            "x": [MU_X],
-            "y": [MU_Y],
-            "sd": [SIGMA],
-            "amplitude": [AMPLITUDE],
+            "x": [BASE_MODEL_PARAMS["mu_x"]],
+            "y": [BASE_MODEL_PARAMS["mu_y"]],
+            "sd": [BASE_MODEL_PARAMS["sigma"]],
+            "amplitude": [BASE_MODEL_PARAMS["amplitude"]],
             "baseline": [0.0],  # no baseline: matches prfmodel with temporal_model=None
         },
     ).astype("float32")
@@ -101,7 +94,7 @@ def main() -> None:
     params = make_params()
     ref = prfmodel_response(stimulus, params, with_hrf=False)
     bc = _braincoder_response(stimulus)
-    passed = check_and_exit(ref, bc, "braincoder (pre-HRF)")
+    passed = compare_predictions(ref, bc, "braincoder (pre-HRF)")
     sys.exit(0 if passed else 1)
 
 

--- a/validation/compare_prfpy.py
+++ b/validation/compare_prfpy.py
@@ -5,17 +5,36 @@ Comparison strategy
 We compare the pre-HRF neural response: the dot product of the Gaussian RF
 with the stimulus design matrix, summed over the spatial dimensions.
 
-HRF is deliberately excluded.  prfpy uses nilearn's SPM HRF basis set (a
-weighted combination of the canonical HRF, its time derivative, and its
-dispersion derivative), while prfmodel uses a custom double-gamma with six
-explicit parameters.  These two formulations cannot be equated by a simple
-parameter mapping, so comparing HRF-convolved outputs would conflate spatial
-and temporal modelling differences.  Comparing the pre-HRF response isolates
-the spatial encoding step — the meaningful invariant between packages.
+The pre-HRF comparison isolates the spatial encoding step,
+the meaningful invariant between packages.
 
 - prfmodel: Gaussian2DPRFModel(impulse_model=None, temporal_model=None)
   normalised RF: exp(-d^2/2*sigma^2) / (2*pi*sigma^2)
 - prfpy:    gauss2D_iso_cart -> unnormalised RF: exp(-d^2/2*sigma^2)
+
+--- Changes in this commit ---
+Adds a second check that compares the full HRF-convolved prediction.  Both
+sides are locked to the SPM canonical double-gamma (no time-derivative
+component) by explicitly setting prfmodel's parameters to match nilearn's
+_gamma_difference_hrf defaults:
+
+  delay=6, dispersion=1, undershoot=16, u_dispersion=1, ratio=1/6, weight_deriv=0
+
+Setting weight_deriv=0 reduces DerivativeTwoGammaImpulse to a plain
+TwoGammaImpulse, so the two kernels are mathematically identical.
+
+Two subtleties to be aware of when reading the prfpy-side implementation:
+
+1. nilearn's spm_hrf(t_r, oversampling=50) returns the kernel on an
+   *oversampled* grid (1600 points at 0.02 s for TR=1).  Using oversampling=1
+   instead shifts the gamma evaluation by loc=dt=1 s, misaligning the peak by a
+   full second.  We therefore fetch the oversampled kernel and downsample by
+   slicing every 50th point, making the shift only 0.02 s (negligible).
+
+2. prfmodel includes baseline and amplitude in its full prediction.  A non-zero
+   baseline adds a constant offset that, after normalisation, changes the shape
+   of the normalised timeseries.  We set baseline=0 and amplitude=1 in the
+   SPM-params DataFrame so both sides return a raw convolved signal.
 
 Coordinate conventions
 ----------------------
@@ -28,6 +47,9 @@ prfpy gauss2D_iso_cart(x, y, mu=(x_pos, y_pos), sigma):
 import sys
 from pathlib import Path
 import numpy as np
+import pandas as pd
+from nilearn.glm.first_level.hemodynamic_models import spm_hrf
+from scipy import signal
 
 try:
     from prfpy.rf import gauss2D_iso_cart
@@ -48,6 +70,24 @@ from shared import load_stimulus
 from shared import make_params
 from shared import prfmodel_response
 
+# SPM canonical double-gamma: weight_deriv=0 collapses DerivativeTwoGamma → TwoGamma.
+# Parameters match nilearn's _gamma_difference_hrf defaults exactly:
+# shape1=delay/dispersion=6, rate1=dispersion=1, shape2=undershoot/u_dispersion=16, rate2=1, c=ratio=1/6.
+_SPM_HRF_PARAMS = {
+    "delay": 6.0,
+    "dispersion": 1.0,
+    "undershoot": 16.0,
+    "u_dispersion": 1.0,
+    "ratio": 1 / 6,
+    "weight_deriv": 0.0,
+}
+
+# Looser tolerance for the with-HRF check: different convolution backends
+# (prfmodel uses Keras depthwise conv, prfpy side uses scipy fftconvolve) and
+# the residual 0.02 s loc shift from the oversampling approach introduce small
+# numerical differences not present in the pre-HRF comparison.
+RTOL_WITH_HRF: float = 1e-3
+
 
 def _prfpy_response(stimulus) -> np.ndarray:
     """Compute pre-HRF response using prfpy's gauss2D_iso_cart.
@@ -67,13 +107,60 @@ def _prfpy_response(stimulus) -> np.ndarray:
     return np.einsum("thw,hw->t", stimulus.design, rf)  # (T,)
 
 
+def _make_spm_params() -> pd.DataFrame:
+    """Return params that lock prfmodel to the SPM canonical double-gamma HRF.
+
+    baseline=0 and amplitude=1 so prfmodel returns the raw convolved signal with
+    no constant offset — directly comparable to the prfpy side.
+    """
+    return pd.DataFrame(
+        {
+            "mu_x": [MU_X],
+            "mu_y": [MU_Y],
+            "sigma": [SIGMA],
+            **{k: [v] for k, v in _SPM_HRF_PARAMS.items()},
+            "baseline": [0.0],
+            "amplitude": [1.0],
+        },
+    )
+
+
+def _prfpy_response_with_hrf(pre_hrf: np.ndarray) -> np.ndarray:
+    """Convolve pre-HRF neural response with the SPM canonical HRF via scipy.
+
+    nilearn's spm_hrf returns the kernel on an oversampled grid (default 50x).
+    Calling it with oversampling=1 introduces a loc=dt=1 s shift that misaligns
+    the kernel by a full second relative to prfmodel's gamma evaluation. Instead
+    we oversample at the default rate and then downsample to 1 s/sample (every 50th
+    point), so the loc shift is only 0.02 s and its effect is negligible.
+
+    TR=1 s is assumed — the resolution at which prfmodel samples its impulse kernel.
+    """
+    oversampling = 50
+    kernel = spm_hrf(t_r=1.0, oversampling=oversampling)[::oversampling]
+    pad_len = len(kernel) - 1
+    padded = np.pad(pre_hrf, (pad_len, 0), mode="edge")
+    convolved = signal.fftconvolve(padded, kernel)
+    return convolved[pad_len : pad_len + len(pre_hrf)]
+
+
 def main() -> None:
-    """Run prfpy comparison and exit with 0 on pass, 1 on fail."""
+    """Run prfpy comparisons and exit with 0 if all pass, 1 if any fail."""
     stimulus = load_stimulus()
+
+    # Pre-HRF check: spatial encoding only.
     params = make_params()
     ref = prfmodel_response(stimulus, params, with_hrf=False)
     prfpy = _prfpy_response(stimulus)
-    check_and_exit(ref, prfpy, "prfpy")
+    passed_pre = check_and_exit(ref, prfpy, "prfpy (pre-HRF)")
+
+    # Full-prediction check: spatial encoding + SPM canonical HRF convolution.
+    spm_params = _make_spm_params()
+    ref_hrf = prfmodel_response(stimulus, spm_params, with_hrf=True)
+    prfpy_hrf = _prfpy_response_with_hrf(_prfpy_response(stimulus))
+    passed_hrf = check_and_exit(ref_hrf, prfpy_hrf, "prfpy (with HRF)", rtol=RTOL_WITH_HRF)
+
+    sys.exit(0 if passed_pre and passed_hrf else 1)
 
 
 if __name__ == "__main__":

--- a/validation/compare_prfpy.py
+++ b/validation/compare_prfpy.py
@@ -2,6 +2,7 @@
 
 Comparison strategy
 -------------------
+--- Non HRF Comparison ---
 We compare the pre-HRF neural response: the dot product of the Gaussian RF
 with the stimulus design matrix, summed over the spatial dimensions.
 
@@ -12,7 +13,7 @@ the meaningful invariant between packages.
   normalised RF: exp(-d^2/2*sigma^2) / (2*pi*sigma^2)
 - prfpy:    gauss2D_iso_cart -> unnormalised RF: exp(-d^2/2*sigma^2)
 
---- Changes in this commit ---
+--- Comparison with including HRF ---
 Adds a second check that compares the full HRF-convolved prediction.  Both
 sides are locked to the SPM canonical double-gamma (no time-derivative
 component) by explicitly setting prfmodel's parameters to match nilearn's
@@ -62,10 +63,9 @@ except ImportError:
     sys.exit(1)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from shared import MU_X
-from shared import MU_Y
-from shared import SIGMA
-from shared import check_and_exit
+from shared import BASE_MODEL_PARAMS
+from shared import PRFStimulus
+from shared import compare_predictions
 from shared import load_stimulus
 from shared import make_params
 from shared import prfmodel_response
@@ -89,7 +89,7 @@ _SPM_HRF_PARAMS = {
 RTOL_WITH_HRF: float = 1e-3
 
 
-def _prfpy_response(stimulus) -> np.ndarray:
+def _prfpy_response(stimulus: PRFStimulus) -> np.ndarray:
     """Compute pre-HRF response using prfpy's gauss2D_iso_cart.
 
     Returns a 1-D array of length n_frames (unnormalised scale).
@@ -100,7 +100,12 @@ def _prfpy_response(stimulus) -> np.ndarray:
     x_grid = stimulus.grid[:, :, 1]  # shape (H, W)
 
     # gauss2D_iso_cart returns exp(-((x-mu_x)^2 + (y-mu_y)^2) / (2*sigma^2)) - unnormalised.
-    rf = gauss2D_iso_cart(x=x_grid, y=y_grid, mu=(MU_X, MU_Y), sigma=SIGMA)  # (H, W)
+    rf = gauss2D_iso_cart(
+        x=x_grid,
+        y=y_grid,
+        mu=(BASE_MODEL_PARAMS["mu_x"], BASE_MODEL_PARAMS["mu_y"]),
+        sigma=BASE_MODEL_PARAMS["sigma"],
+    )  # (H, W)
 
     # Project RF onto stimulus: sum over spatial dims for each time frame.
     # design shape: (T, H, W)
@@ -115,12 +120,12 @@ def _make_spm_params() -> pd.DataFrame:
     """
     return pd.DataFrame(
         {
-            "mu_x": [MU_X],
-            "mu_y": [MU_Y],
-            "sigma": [SIGMA],
+            "mu_x": [BASE_MODEL_PARAMS["mu_x"]],
+            "mu_y": [BASE_MODEL_PARAMS["mu_y"]],
+            "sigma": [BASE_MODEL_PARAMS["sigma"]],
             **{k: [v] for k, v in _SPM_HRF_PARAMS.items()},
-            "baseline": [0.0],
-            "amplitude": [1.0],
+            "baseline": [0.0],  # no baseline: prfpy does not support baseline
+            "amplitude": [1.0],  # no amplitude: prfpy returns unscaled signal
         },
     )
 
@@ -152,13 +157,13 @@ def main() -> None:
     params = make_params()
     ref = prfmodel_response(stimulus, params, with_hrf=False)
     prfpy = _prfpy_response(stimulus)
-    passed_pre = check_and_exit(ref, prfpy, "prfpy (pre-HRF)")
+    passed_pre = compare_predictions(ref, prfpy, "prfpy (pre-HRF)")
 
     # Full-prediction check: spatial encoding + SPM canonical HRF convolution.
     spm_params = _make_spm_params()
     ref_hrf = prfmodel_response(stimulus, spm_params, with_hrf=True)
     prfpy_hrf = _prfpy_response_with_hrf(_prfpy_response(stimulus))
-    passed_hrf = check_and_exit(ref_hrf, prfpy_hrf, "prfpy (with HRF)", rtol=RTOL_WITH_HRF)
+    passed_hrf = compare_predictions(ref_hrf, prfpy_hrf, "prfpy (with HRF)", rtol=RTOL_WITH_HRF)
 
     sys.exit(0 if passed_pre and passed_hrf else 1)
 

--- a/validation/compare_prfpy.py
+++ b/validation/compare_prfpy.py
@@ -1,0 +1,80 @@
+"""Validate prfmodel's 2D Gaussian pRF against prfpy.
+
+Comparison strategy
+-------------------
+We compare the pre-HRF neural response: the dot product of the Gaussian RF
+with the stimulus design matrix, summed over the spatial dimensions.
+
+HRF is deliberately excluded.  prfpy uses nilearn's SPM HRF basis set (a
+weighted combination of the canonical HRF, its time derivative, and its
+dispersion derivative), while prfmodel uses a custom double-gamma with six
+explicit parameters.  These two formulations cannot be equated by a simple
+parameter mapping, so comparing HRF-convolved outputs would conflate spatial
+and temporal modelling differences.  Comparing the pre-HRF response isolates
+the spatial encoding step — the meaningful invariant between packages.
+
+- prfmodel: Gaussian2DPRFModel(impulse_model=None, temporal_model=None)
+  normalised RF: exp(-d^2/2*sigma^2) / (2*pi*sigma^2)
+- prfpy:    gauss2D_iso_cart -> unnormalised RF: exp(-d^2/2*sigma^2)
+
+Coordinate conventions
+----------------------
+prfmodel stimulus grid: shape (H, W, 2), last axis = [y, x] in visual-angle degrees.
+prfpy gauss2D_iso_cart(x, y, mu=(x_pos, y_pos), sigma):
+  - first positional arg is the x-grid, second is the y-grid
+  - mu[0] = x centre, mu[1] = y centre
+"""
+
+import sys
+from pathlib import Path
+import numpy as np
+
+try:
+    from prfpy.rf import gauss2D_iso_cart
+except ImportError:
+    print(
+        "ERROR: prfpy is not installed.\n"
+        "Install with: pip install prfpy\n"
+        "or: pip install git+https://github.com/VU-Cog-Sci/prfpy.git",
+    )
+    sys.exit(1)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from shared import MU_X
+from shared import MU_Y
+from shared import SIGMA
+from shared import check_and_exit
+from shared import load_stimulus
+from shared import make_params
+from shared import prfmodel_response
+
+
+def _prfpy_response(stimulus) -> np.ndarray:
+    """Compute pre-HRF response using prfpy's gauss2D_iso_cart.
+
+    Returns a 1-D array of length n_frames (unnormalised scale).
+    """
+    # Extract x and y coordinate grids from the prfmodel stimulus.
+    # grid[:, :, 0] = y-axis, grid[:, :, 1] = x-axis (dimension_labels=['y', 'x'])
+    y_grid = stimulus.grid[:, :, 0]  # shape (H, W)
+    x_grid = stimulus.grid[:, :, 1]  # shape (H, W)
+
+    # gauss2D_iso_cart returns exp(-((x-mu_x)^2 + (y-mu_y)^2) / (2*sigma^2)) - unnormalised.
+    rf = gauss2D_iso_cart(x=x_grid, y=y_grid, mu=(MU_X, MU_Y), sigma=SIGMA)  # (H, W)
+
+    # Project RF onto stimulus: sum over spatial dims for each time frame.
+    # design shape: (T, H, W)
+    return np.einsum("thw,hw->t", stimulus.design, rf)  # (T,)
+
+
+def main() -> None:
+    """Run prfpy comparison and exit with 0 on pass, 1 on fail."""
+    stimulus = load_stimulus()
+    params = make_params()
+    ref = prfmodel_response(stimulus, params, with_hrf=False)
+    prfpy = _prfpy_response(stimulus)
+    check_and_exit(ref, prfpy, "prfpy")
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/shared.py
+++ b/validation/shared.py
@@ -26,12 +26,15 @@ os.environ.setdefault("KERAS_BACKEND", "tensorflow")
 
 from prfmodel.examples import load_2d_prf_bar_stimulus
 from prfmodel.models import Gaussian2DPRFModel
+from prfmodel.stimuli import PRFStimulus
 
-MU_X: float = -2.1
-MU_Y: float = 1.45
-SIGMA: float = 1.35
-AMPLITUDE: float = 1.2
-BASELINE: float = 10.0
+BASE_MODEL_PARAMS: dict = {
+    "mu_x": -2.1,
+    "mu_y": 1.45,
+    "sigma": 1.35,
+    "amplitude": 1.2,
+    "baseline": 10.0,
+}
 
 HRF_PARAMS: dict = {
     "delay": 6.0,
@@ -46,7 +49,7 @@ HRF_PARAMS: dict = {
 RTOL: float = 1e-4
 
 
-def load_stimulus():
+def load_stimulus() -> PRFStimulus:
     """Return the standard bar stimulus (design: 200 x 101 x 101, FOV: 20 deg)."""
     return load_2d_prf_bar_stimulus()
 
@@ -55,17 +58,17 @@ def make_params() -> pd.DataFrame:
     """Return a one-row DataFrame with pre-chosen parameters."""
     return pd.DataFrame(
         {
-            "mu_x": [MU_X],
-            "mu_y": [MU_Y],
-            "sigma": [SIGMA],
+            "mu_x": [BASE_MODEL_PARAMS["mu_x"]],
+            "mu_y": [BASE_MODEL_PARAMS["mu_y"]],
+            "sigma": [BASE_MODEL_PARAMS["sigma"]],
             **{k: [v] for k, v in HRF_PARAMS.items()},
-            "baseline": [BASELINE],
-            "amplitude": [AMPLITUDE],
+            "baseline": [BASE_MODEL_PARAMS["baseline"]],
+            "amplitude": [BASE_MODEL_PARAMS["amplitude"]],
         },
     )
 
 
-def prfmodel_response(stimulus, params: pd.DataFrame, *, with_hrf: bool = False) -> np.ndarray:
+def prfmodel_response(stimulus: PRFStimulus, params: pd.DataFrame, *, with_hrf: bool = False) -> np.ndarray:
     """Return prfmodel's 2D Gaussian pRF prediction as a 1-D NumPy array.
 
     When with_hrf=False (default) the impulse and temporal models are disabled,
@@ -82,7 +85,7 @@ def normalize(arr: np.ndarray) -> np.ndarray:
     return arr / total if total > 0 else arr
 
 
-def check_and_exit(a: np.ndarray, b: np.ndarray, package: str, *, rtol: float = RTOL) -> bool:
+def compare_predictions(a: np.ndarray, b: np.ndarray, package: str, *, rtol: float = RTOL) -> bool:
     """Compare two normalised timeseries; print result and return True (pass) or False (fail).
 
     Returns bool rather than calling sys.exit so that callers running multiple

--- a/validation/shared.py
+++ b/validation/shared.py
@@ -1,18 +1,23 @@
 """Shared fixtures and utilities for cross-package pRF validation.
 
-Stimulus and parameters mirror the diff_gaussians tutorial exactly.
+Stimulus and parameters mirror the diff_gaussians tutorial.
 
-HRF comparison is deliberately excluded from all cross-package checks.  Each
+HRF comparison is by default excluded from cross-package checks, because each
 package implements its own HRF (nilearn SPM canonical, TDM lookup table, custom
 double-gamma) with parameters that do not map directly across implementations.
 Comparing the pre-HRF neural response — the dot product of the Gaussian RF with
 the stimulus design matrix — isolates the spatial encoding step and makes the
 comparison package-agnostic: if the RF and the projection agree, any remaining
 differences in the full prediction must come from the temporal model.
+
+--- Changes in this commit: PRFpy with HRF validation ---
+check_and_exit now returns bool instead of calling sys.exit, and accepts an
+optional rtol keyword argument (default RTOL).  This allows a single script to
+run multiple checks, collect all results, and exit once at the end — which is
+needed for the prfpy with-HRF check added in compare_prfpy.py.
 """
 
 import os
-import sys
 import numpy as np
 import pandas as pd
 
@@ -77,20 +82,20 @@ def normalize(arr: np.ndarray) -> np.ndarray:
     return arr / total if total > 0 else arr
 
 
-def check_and_exit(a: np.ndarray, b: np.ndarray, package: str) -> None:
-    """Compare two timeseries and exit with 0 (pass) or 1 (fail).
+def check_and_exit(a: np.ndarray, b: np.ndarray, package: str, *, rtol: float = RTOL) -> bool:
+    """Compare two normalised timeseries; print result and return True (pass) or False (fail).
+
+    Returns bool rather than calling sys.exit so that callers running multiple
+    checks can collect all results before deciding the final exit code.
 
     Both arrays are normalized to unit absolute sum before comparison
     to handle RF scale differences across packages.
     """
     a_norm = normalize(a)
     b_norm = normalize(b)
-    passed = np.allclose(a_norm, b_norm, rtol=RTOL)
+    passed = np.allclose(a_norm, b_norm, rtol=rtol)
     max_diff = float(np.abs(a_norm - b_norm).max())
     label = f"prfmodel vs {package} (normalised)"
     status = "PASS" if passed else "FAIL"
-    print(f"{status}  {label}  max_diff={max_diff:.2e}  rtol={RTOL}")
-    if passed:
-        sys.exit(0)
-    else:
-        sys.exit(1)
+    print(f"{status}  {label}  max_diff={max_diff:.2e}  rtol={rtol}")
+    return passed

--- a/validation/shared.py
+++ b/validation/shared.py
@@ -1,0 +1,96 @@
+"""Shared fixtures and utilities for cross-package pRF validation.
+
+Stimulus and parameters mirror the diff_gaussians tutorial exactly.
+
+HRF comparison is deliberately excluded from all cross-package checks.  Each
+package implements its own HRF (nilearn SPM canonical, TDM lookup table, custom
+double-gamma) with parameters that do not map directly across implementations.
+Comparing the pre-HRF neural response — the dot product of the Gaussian RF with
+the stimulus design matrix — isolates the spatial encoding step and makes the
+comparison package-agnostic: if the RF and the projection agree, any remaining
+differences in the full prediction must come from the temporal model.
+"""
+
+import os
+import sys
+import numpy as np
+import pandas as pd
+
+# Must be set before importing prfmodel (selects the Keras backend).
+os.environ.setdefault("KERAS_BACKEND", "tensorflow")
+
+from prfmodel.examples import load_2d_prf_bar_stimulus
+from prfmodel.models import Gaussian2DPRFModel
+
+MU_X: float = -2.1
+MU_Y: float = 1.45
+SIGMA: float = 1.35
+AMPLITUDE: float = 1.2
+BASELINE: float = 10.0
+
+HRF_PARAMS: dict = {
+    "delay": 6.0,
+    "dispersion": 0.9,
+    "undershoot": 12.0,
+    "u_dispersion": 0.9,
+    "ratio": 0.48,
+    "weight_deriv": -0.5,
+}
+
+# Relative tolerance for normalised timeseries comparison.
+RTOL: float = 1e-4
+
+
+def load_stimulus():
+    """Return the standard bar stimulus (design: 200 x 101 x 101, FOV: 20 deg)."""
+    return load_2d_prf_bar_stimulus()
+
+
+def make_params() -> pd.DataFrame:
+    """Return a one-row DataFrame with pre-chosen parameters."""
+    return pd.DataFrame(
+        {
+            "mu_x": [MU_X],
+            "mu_y": [MU_Y],
+            "sigma": [SIGMA],
+            **{k: [v] for k, v in HRF_PARAMS.items()},
+            "baseline": [BASELINE],
+            "amplitude": [AMPLITUDE],
+        },
+    )
+
+
+def prfmodel_response(stimulus, params: pd.DataFrame, *, with_hrf: bool = False) -> np.ndarray:
+    """Return prfmodel's 2D Gaussian pRF prediction as a 1-D NumPy array.
+
+    When with_hrf=False (default) the impulse and temporal models are disabled,
+    returning only the normalised Gaussian RF projected onto the stimulus design.
+    """
+    model = Gaussian2DPRFModel() if with_hrf else Gaussian2DPRFModel(impulse_model=None, temporal_model=None)
+    return np.asarray(model(stimulus, params)).ravel()
+
+
+def normalize(arr: np.ndarray) -> np.ndarray:
+    """Normalize a 1-D array to unit absolute sum."""
+    arr = np.asarray(arr, dtype=float).ravel()
+    total = np.abs(arr).sum()
+    return arr / total if total > 0 else arr
+
+
+def check_and_exit(a: np.ndarray, b: np.ndarray, package: str) -> None:
+    """Compare two timeseries and exit with 0 (pass) or 1 (fail).
+
+    Both arrays are normalized to unit absolute sum before comparison
+    to handle RF scale differences across packages.
+    """
+    a_norm = normalize(a)
+    b_norm = normalize(b)
+    passed = np.allclose(a_norm, b_norm, rtol=RTOL)
+    max_diff = float(np.abs(a_norm - b_norm).max())
+    label = f"prfmodel vs {package} (normalised)"
+    status = "PASS" if passed else "FAIL"
+    print(f"{status}  {label}  max_diff={max_diff:.2e}  rtol={RTOL}")
+    if passed:
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION
I included comparisons with `prfpy` and `braincoder`. The validation is using gaussian2D predictions without HRF convolutions. For the case of `prfpy` it appears to be comparable using the `GammaImpulse` but I am not sure it is a proper comparison.

The validation can be run as a workflow but because I can't commit anything into main the workflow is not visible to be run here. I tested the workflows locally using `act`. The basic validation runs, but the  gaussian + impulse one might be failing...