### PR TITLE
103 cosine similarity loss should be default in grid search

### DIFF
--- a/docs/tutorials/examples/cf_fmri_visual.md
+++ b/docs/tutorials/examples/cf_fmri_visual.md
@@ -379,17 +379,15 @@ The grid search will evaluate all possible combinations of the defined ranges an
 data best. Note that this is still a relatively small grid and we recommend specifying finer grids in practice.
 
 Let's construct the {py:class}`prfmodel.fitters.grid.GridFitter` and perform the grid search. Note that we set `batch_size=20` to let the {py:class}`prfmodel.fitters.grid.GridFitter`
-evaluate 20 parameter combinations at the same time (which saves us some memory). As the `loss` (i.e., the metric to minimize between model predictions and data), we use cosine similarity which ignores differences in scale between model predictions and observed data.
+evaluate 20 parameter combinations at the same time (which saves us some memory). By default, the `loss` (i.e., the metric to minimize between model predictions and data) is cosine similarity, which ignores differences in scale between model predictions and observed data.
 
 ```{code-cell} ipython3
-from keras.losses import CosineSimilarity
 from prfmodel.fitters import GridFitter
 
 # Create grid fitter object
 grid_fitter = GridFitter(
     model=cf_model,
     stimulus=stimulus,
-    loss=CosineSimilarity(reduction="none"),  # Grid fitter needs no aggregation of loss
 )
 
 # Run grid search

--- a/docs/tutorials/examples/prf_2d_fmri_visual.md
+++ b/docs/tutorials/examples/prf_2d_fmri_visual.md
@@ -456,17 +456,15 @@ grid search will evaluate all possible combinations of these values and return t
 data best. This will result in a grid containing $20 ^ 3 = 8000$ parameter combinations. This is still a relatively small grid and we recommend specifying finer grids in practice.
 
 Let's construct the {py:class}`prfmodel.fitters.grid.GridFitter` and perform the grid search. Note that we set `batch_size=20` to let the {py:class}`prfmodel.fitters.grid.GridFitter`
-evaluate 20 parameter combinations at the same time (which saves us some memory). As the `loss` (i.e., the metric to minimize between model predictions and data), we use cosine similarity which ignores differences in scale between model predictions and observed data.
+evaluate 20 parameter combinations at the same time (which saves us some memory). By default, the `loss` (i.e., the metric to minimize between model predictions and data) is cosine similarity, which ignores differences in scale between model predictions and observed data.
 
 ```{code-cell} ipython3
-from keras.losses import CosineSimilarity
 from prfmodel.fitters import GridFitter
 
 # Create grid fitter object
 grid_fitter = GridFitter(
     model=prf_model,
     stimulus=stimulus,
-    loss=CosineSimilarity(reduction="none"),  # Grid fitter needs no aggregation of loss
 )
 
 # Run grid search

--- a/docs/tutorials/tutorials/div_norm_prf_simulated.md
+++ b/docs/tutorials/tutorials/div_norm_prf_simulated.md
@@ -188,17 +188,15 @@ param_ranges_gaussian = {
 ```
 
 For all three parameters, we defined ranges of 10 values, giving the fitter $10 \times 10 \times 10 = 1000$
-parameter combinations to evaluate. Let's construct the `GridFitter` and run the grid search. Note that we are using
-a cosine similarity loss function that ignores differences in scale between model predictions and data.
+parameter combinations to evaluate. Let's construct the `GridFitter` and run the grid search. By default, the
+`GridFitter` uses a cosine similarity loss function that ignores differences in scale between model predictions and data.
 
 ```{code-cell} ipython3
-from keras.losses import CosineSimilarity
 from prfmodel.fitters import GridFitter
 
 grid_fitter = GridFitter(
     model=gaussian_model,
     stimulus=stimulus,
-    loss=CosineSimilarity(reduction="none"),
 )
 
 grid_history, grid_params = grid_fitter.fit(

--- a/docs/tutorials/tutorials/regressors.md
+++ b/docs/tutorials/tutorials/regressors.md
@@ -145,10 +145,10 @@ fig.legend();
 We can see that the predicted neural response contains some "noise" coming from the two regressors.
 
 Our next goal is to fit the model back to its own predicted neural timecourse. We first use a grid search to optimize
-the center and size of the Gaussian pRF (i.e., `mu_x`, `mu_y`, `sigma`).
+the center and size of the Gaussian pRF (i.e., `mu_x`, `mu_y`, `sigma`). By default, the `GridFitter` uses a cosine
+similarity loss function that ignores differences in scale between model predictions and data.
 
 ```{code-cell} ipython3
-from keras.losses import CosineSimilarity
 from prfmodel.fitters import GridFitter
 
 param_grid = {
@@ -165,7 +165,6 @@ param_grid = {
 grid_fitter = GridFitter(
     model=prf_model,
     stimulus=stimulus,
-    loss=CosineSimilarity(reduction="none"),
 )
 
 _, grid_params = grid_fitter.fit(

--- a/src/prfmodel/fitters/_grid.py
+++ b/src/prfmodel/fitters/_grid.py
@@ -50,7 +50,7 @@ class GridFitter:
     %(stimulus)s
     loss : keras.optimizers.Loss or Callable, optional
         Loss instance or function with the signature `f(y, y_pred)`, where `y` is the target data and `y_pred` are the
-        model predicitons. Default is `None` where a `keras.optimizers.MeanSquaredError` loss is used. Note that, when
+        model predicitons. Default is `None` where a `keras.losses.CosineSimilarity` loss is used. Note that, when
         a `keras.losses.Loss` instance is used, the argument `reduction` must be set to `"none"` to enable loss
         computation for all data batches.
     %(dtype)s
@@ -99,7 +99,7 @@ class GridFitter:
         self.stimulus = stimulus
 
         if loss is None:
-            loss = keras.losses.MeanSquaredError(reduction="none")
+            loss = keras.losses.CosineSimilarity(reduction="none")
 
         self.loss = loss
         self.dtype = dtype

--- a/tests/fitters/test_grid.py
+++ b/tests/fitters/test_grid.py
@@ -52,7 +52,7 @@ class TestGridFitter(TestSetup):
     @parametrize_impulse_model
     @pytest.mark.parametrize(
         "loss",
-        [None, keras.losses.MeanSquaredError(reduction="none")],
+        [None, keras.losses.CosineSimilarity(reduction="none")],
     )
     def test_fit(  # noqa: PLR0913 (too many arguments in function definition)
         self,


### PR DESCRIPTION
In theory this is only a change in line 102 of `_grid.py` (and its docstring). 

As a consequence, 4 tutorials that where explicitly coding the CosineSimilarity now are only called with the default loss, but a comment was added mentioning that CosineSimilarity is being used. 

Also the loss test was updated.