### PR TITLE
adding uv instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,47 @@ jobs:
           KERAS_BACKEND: ${{ matrix.backend }}
           JAX_ENABLE_X64: "true"
 
+  uv-install:
+    name: Install with uv (${{ matrix.backend }}), as documented in docs/installation.md
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: ['tensorflow', 'torch', 'jax']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: '3.12'
+      - name: Create a venv and install prfmodel with uv, mirroring the docs
+        run: |
+          uv venv
+          uv pip install ".[${{ matrix.backend }}]"
+      - name: Verify the package installed correctly
+        run: |
+          source .venv/bin/activate
+          python -c "import prfmodel; from prfmodel.fitters import GridFitter"
+        env:
+          KERAS_BACKEND: ${{ matrix.backend }}
+          JAX_ENABLE_X64: "true"
+
+  uv-dev:
+    name: Set up dev environment with uv, as documented in README.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: '3.12'
+      - name: Sync dev environment with uv (as documented; tensorflow added to enable running the test suite)
+        run: uv sync --extra dev --extra tensorflow
+      - name: Run unit tests in the uv-managed environment
+        run: uv run pytest -v
+        env:
+          KERAS_BACKEND: tensorflow
+
   mypy:
     name: Check types with mypy
     runs-on: 'ubuntu-latest'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ To install the JAX backend, run:
 python -m pip install .[jax]
 ```
 
+We also support installing with [uv](https://docs.astral.sh/uv/) as a fast drop-in alternative to `pip`, e.g.
+`uv pip install '.[tensorflow]'`. See the [installation docs](https://popylar-org.github.io/prfmodel/installation.html)
+for the full set of pip- and uv-based instructions.
+
 ## Documentation
 
 The online documentation is available at: https://popylar-org.github.io/prfmodel/.
@@ -68,10 +72,22 @@ with development dependencies, run:
 python -m pip install -e .[dev]
 ```
 
+Or, with uv, which also manages the virtual environment and dependency locking for you:
+
+```console
+uv sync --extra dev
+```
+
 The test suite can be run with:
 
 ```console
 python -m pytest
+```
+
+or, in the uv-managed environment:
+
+```console
+uv run pytest
 ```
 
 ## Credits

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,8 +13,13 @@ git clone git@github.com:popylar-org/prfmodel.git
 cd prfmodel
 ```
 
-We recommend installing prfmodel in a virtual environment to prevent conflicts with other packages,
-for example using [venv](https://docs.python.org/3/library/venv.html).
+We recommend installing prfmodel in a virtual environment to prevent conflicts with other packages, for example using
+[venv](https://docs.python.org/3/library/venv.html) with `pip`, or [uv](https://docs.astral.sh/uv/), a fast drop-in
+alternative to `pip` that we also support.
+
+``````````````{tab-set}
+
+`````````````{tab-item} pip
 
 ````````{tab-set}
 
@@ -44,31 +49,105 @@ To install the development version of prfmodel from the local clone of the repos
 
 ``````{tab-item} Tensorflow
 ```bash
-python -m pip install .[tensorflow]
+python -m pip install ".[tensorflow]"
 ```
 ``````
 
 ``````{tab-item} PyTorch
 ```bash
-python -m pip install .[torch]
+python -m pip install ".[torch]"
 ```
 ``````
 
 ``````{tab-item} JAX
 ```bash
-python -m pip install .[jax]
+python -m pip install ".[jax]"
 ```
 ``````
 
 ````````
 
+`````````````
+
+`````````````{tab-item} uv
+
+First, [install uv](https://docs.astral.sh/uv/getting-started/installation/) if you don't have it already.
+
+````````{tab-set}
+
+``````{tab-item} Windows
+```console
+uv venv my_venv # Create a virtual environment called 'my_venv'
+my_venv\Scripts\activate.bat # Activate the virtual environment
+```
+``````
+
+``````{tab-item} Unix (MacOS / Linux)
+```bash
+uv venv my_venv  # Create a virtual environment called 'my_venv'
+source my_venv/bin/activate  # Activate the virtual environment
+```
+``````
+
+````````
+
+prfmodel relies on [Keras](https://keras.io/) to enable users to use different backends for model fitting.
+Currently, users can choose between three backends: TensorFlow, PyTorch, and JAX. If you don't know which backend to
+choose, we recommend to start with TensorFlow.
+
+To install the development version of prfmodel from the local clone of the repository with a backend:
+
+````````{tab-set}
+
+``````{tab-item} Tensorflow
+```bash
+uv pip install ".[tensorflow]"
+```
+``````
+
+``````{tab-item} PyTorch
+```bash
+uv pip install ".[torch]"
+```
+``````
+
+``````{tab-item} JAX
+```bash
+uv pip install ".[jax]"
+```
+``````
+
+````````
+
+`````````````
+
+``````````````
+
 ## Installing dependencies for package development
 
 For those who want to contribute to the package development, you can make an editable install of the package and
-install all required additional dependencies via:
+install all required additional dependencies.
 
+``````{tab-set}
+
+`````{tab-item} pip
 ```bash
 git clone git@github.com:popylar-org/prfmodel.git
 cd prfmodel
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
+`````
+
+`````{tab-item} uv
+```bash
+git clone git@github.com:popylar-org/prfmodel.git
+cd prfmodel
+uv sync --extra dev
+```
+This creates and manages a `.venv` for you automatically (no separate venv-creation or activation step needed) and
+uses a `uv.lock` file to keep everyone's development environment reproducible. Prefix commands with `uv run`
+(e.g. `uv run pytest`) to run them inside this environment, or activate it as usual with `source .venv/bin/activate`
+(Unix) / `.venv\Scripts\activate.bat` (Windows).
+`````
+
+``````


### PR DESCRIPTION
Added it as a secondary alternative, pip is still the main installation path, so beginner users do not get confused. 

The instructions added are via "uv pip ..." instead of adding a `uv.lock` file, to avoid having to sync it with `pyproject.toml` everytime there are major updates? But for reproducibility it might be better to use the `uv.lock`...

The development environment is the only one using `uv sync`, since advanced developers might prefer to fully use uv.