### PR TITLE
Move scaling models tests into separate directory

### DIFF
--- a/tests/scaling/test_amplitude.py
+++ b/tests/scaling/test_amplitude.py
@@ -1,0 +1,49 @@
+"""Tests for BaselineAmplitude scaling model class."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from prfmodel.exceptions import ShapeError
+from prfmodel.scaling import BaselineAmplitude
+from tests.models.conftest import parametrize_dtype
+
+
+class TestBaselineAmplitude:
+    """Tests for BaselineAmplitude class."""
+
+    num_frames = 10
+
+    @pytest.fixture
+    def model(self):
+        """Model object."""
+        return BaselineAmplitude()
+
+    @pytest.fixture
+    def params(self):
+        """Model parameters."""
+        return pd.DataFrame(
+            {
+                "baseline": [5.0, 10.0, -3.0],
+                "amplitude": [2.0, -1.0, 1.0],
+            },
+        )
+
+    @parametrize_dtype
+    def test_call(self, model: BaselineAmplitude, params: pd.DataFrame, dtype: str):
+        """Test that BaselineAmplitude returns response with correct shape."""
+        inputs = np.ones((params.shape[0], self.num_frames))
+
+        resp = model(inputs, params, dtype)
+
+        assert resp.shape == inputs.shape
+        assert np.allclose(
+            resp,
+            inputs * np.expand_dims(params["amplitude"], 1) + np.expand_dims(params["baseline"], 1),
+        )
+
+    def test_shape_error(self, model: BaselineAmplitude, params: pd.DataFrame):
+        """Test that ShapeError is raised."""
+        inputs = np.ones(self.num_frames)
+
+        with pytest.raises(ShapeError):
+            model(inputs, params)

--- a/tests/scaling/test_base.py
+++ b/tests/scaling/test_base.py
@@ -1,0 +1,15 @@
+"""Test scaling model base classes."""
+
+import pytest
+from prfmodel.scaling.base import BaseScaling
+
+
+class TestBaseScaling:
+    """Tests for BaseScaling class."""
+
+    model_class = BaseScaling
+
+    def test_abstract_fail(self):
+        """Test that model instantiation fails."""
+        with pytest.raises(TypeError):
+            _ = self.model_class()

--- a/tests/scaling/test_baseline.py
+++ b/tests/scaling/test_baseline.py
@@ -1,22 +1,22 @@
-"""Tests for temporal model classes."""
+"""Tests for Baseline scaling model class."""
 
 import numpy as np
 import pandas as pd
 import pytest
 from prfmodel.exceptions import ShapeError
-from prfmodel.scaling import BaselineAmplitude
-from .conftest import parametrize_dtype
+from prfmodel.scaling import Baseline
+from tests.models.conftest import parametrize_dtype
 
 
-class TestBaselineAmplitdue:
-    """Tests for BaselineAmplitude class."""
+class TestBaseline:
+    """Tests for Baseline class."""
 
     num_frames = 10
 
     @pytest.fixture
     def model(self):
         """Model object."""
-        return BaselineAmplitude()
+        return Baseline()
 
     @pytest.fixture
     def params(self):
@@ -24,24 +24,20 @@ class TestBaselineAmplitdue:
         return pd.DataFrame(
             {
                 "baseline": [5.0, 10.0, -3.0],
-                "amplitude": [2.0, -1.0, 1.0],
             },
         )
 
     @parametrize_dtype
-    def test_call(self, model: BaselineAmplitude, params: pd.DataFrame, dtype: str):
-        """Test that BaselineAmplitude returns response with correct shape."""
+    def test_call(self, model: Baseline, params: pd.DataFrame, dtype: str):
+        """Test that Baseline returns response with correct shape."""
         inputs = np.ones((params.shape[0], self.num_frames))
 
         resp = model(inputs, params, dtype)
 
         assert resp.shape == inputs.shape
-        assert np.allclose(
-            resp,
-            inputs * np.expand_dims(params["amplitude"], 1) + np.expand_dims(params["baseline"], 1),
-        )
+        assert np.allclose(resp, inputs + np.expand_dims(params["baseline"], 1))
 
-    def test_shape_error(self, model: BaselineAmplitude, params: pd.DataFrame):
+    def test_shape_error(self, model: Baseline, params: pd.DataFrame):
         """Test that ShapeError is raised."""
         inputs = np.ones(self.num_frames)
 


### PR DESCRIPTION
The tests for scaling models are still in the `tests/models` directory but should be in a separate `tests/scaling` directory to mirror the package structure.