### PR TITLE
Upgrade numpy, Keras, and Python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-cached

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ with prfmodel.
 
 ## Installation
 
-**Requirements**: prfmodel requires Python version >= 3.10 and <= 3.12.
+**Requirements**: prfmodel requires Python version >= 3.10 and <= 3.13.
 
 To install the development version of prfmodel from GitHub, run:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 The prfmodel package is currently only available as a development version that must be installed from GitHub.
 Please note that this version is still under active development and subject to constant change.
-Installing prfmodel requires Python version >= 3.10 and <= 3.12.
+Installing prfmodel requires Python version >= 3.10 and <= 3.13.
 
 ## Installing the development version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "keras>=3.5.0",
@@ -40,7 +41,7 @@ keywords = [""]
 license = {file = "LICENSE"}
 name = "prfmodel"
 readme = {file = "README.md", content-type = "text/markdown"}
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 version = "0.0.1"
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "keras",
+    "keras>=3.5.0",
     "matplotlib",
     "more-itertools",
     "nilearn",
-    "numpy<2.0.0",
+    "numpy>=2.0.0",
     "pandas",
     "scipy",
     "tqdm"

--- a/src/prfmodel/fitters/adapter.py
+++ b/src/prfmodel/fitters/adapter.py
@@ -8,6 +8,7 @@ This module contains functionality to transform parameters during model fitting
 from collections.abc import Callable
 from collections.abc import Sequence
 from typing import TypeVar
+from typing import cast
 import pandas as pd
 from keras import ops
 from prfmodel._docstring import doc
@@ -246,6 +247,10 @@ class ParameterConstraint(ParameterTransform):
             msg = "Lower and upper bound must not be provided at the same time"
             raise NotImplementedError(msg)
 
+        if lower is None and upper is None:
+            msg = "Either a lower or an upper bound must be provided"
+            raise ValueError(msg)
+
         self.lower = lower
         self.upper = upper
 
@@ -284,8 +289,10 @@ class ParameterConstraint(ParameterTransform):
         self._check_bound_name(self.lower, parameters)
         parameters = parameters.copy()
 
-        lower = parameters[self.lower] if isinstance(self.lower, str) else self.lower
-        lower = self.bound_fun(lower)
+        bound = parameters[self.lower] if isinstance(self.lower, str) else self.lower
+        # The bound cannot be None here: this method only runs when a lower bound was given, and
+        # `__init__` rejects a constraint with no bound at all. `cast` tells the type checker that.
+        lower = cast("Tensor | float", self.bound_fun(bound))
 
         for param in self.parameter_names:
             distance = parameters[param] - lower
@@ -298,8 +305,9 @@ class ParameterConstraint(ParameterTransform):
         self._check_bound_name(self.upper, parameters)
         parameters = parameters.copy()
 
-        upper = parameters[self.upper] if isinstance(self.upper, str) else self.upper
-        upper = self.bound_fun(upper)
+        bound = parameters[self.upper] if isinstance(self.upper, str) else self.upper
+        # Cast for the same reason as in `_transform_lower`: an upper bound is guaranteed here.
+        upper = cast("Tensor | float", self.bound_fun(bound))
 
         for param in self.parameter_names:
             distance = upper - parameters[param]

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -251,6 +251,12 @@ def test_parameter_constraint_bound_fun_applied(params_wrapper: type, bounded_pa
     np.testing.assert_array_less(np.asarray(result["low"]) + 1.0, np.asarray(result["x"]))
 
 
+def test_parameter_constraint_no_bound_error():
+    """Test that providing neither bound returns an error."""
+    with pytest.raises(ValueError, match="Either a lower or an upper bound"):
+        _ = ParameterConstraint(parameter_names=["x"])
+
+
 def test_parameter_constraint_lower_upper_error():
     """Test that providing lower and upper bound returns an error."""
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Restricts numpy to version >= 2.0.0 which implies keras >= 3.5.

Increases the max Python version to 3.13 (which requires numpy >= 2.0.0).