### PR TITLE
Add correlation loss as default for grid search

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -111,6 +111,10 @@ Let's start with the grid search by defining ranges of `mu_x`, `mu_y`, and `sigm
 of parameter values from. For all other parameters, we only provide a single value so that they will stay constant
 across the entire grid.
 
+Note that we set `baseline` to `0.0` and `amplitude` to `1.0` even though we simulated the data with a `baseline` of
+`10.0`. This is difference is on purpose because, by default, the `GridFitter` minimizes the negative correlation between prediction and data, which is unaffected by the baseline and amplitude of the prediction. Any value works here, and we estimate
+both parameters properly with least squares in the next step.
+
 ```{code-cell} ipython3
 import numpy as np
 
@@ -128,7 +132,7 @@ For all three parameters, we defined ranges of 10 values that will be used to co
 grid search will evaluate all possible combinations of these values and return the combination that fits the simulated
 data best. This will result in a grid containing $10 \times 10 \times 10 = 1000$ parameter combinations.
 
-Let's construct the `GridFitter` and perform the grid search. Note that we set `chunk_size=20` to let the `GridFitter`
+Let's construct the `GridFitter` and perform the grid search. Note that we set `batch_size=20` to let the `GridFitter`
 evaluate 20 parameter combinations at the same time (which saves us some memory).
 
 ```{code-cell} ipython3

--- a/docs/tutorials/examples/cf_fmri_visual.md
+++ b/docs/tutorials/examples/cf_fmri_visual.md
@@ -379,7 +379,7 @@ The grid search will evaluate all possible combinations of the defined ranges an
 data best. Note that this is still a relatively small grid and we recommend specifying finer grids in practice.
 
 Let's construct the {py:class}`prfmodel.fitters.grid.GridFitter` and perform the grid search. Note that we set `batch_size=20` to let the {py:class}`prfmodel.fitters.grid.GridFitter`
-evaluate 20 parameter combinations at the same time (which saves us some memory). By default, the `loss` (i.e., the metric to minimize between model predictions and data) is cosine similarity, which ignores differences in scale between model predictions and observed data.
+evaluate 20 parameter combinations at the same time (which saves us some memory). By default, the `loss` (i.e., the metric to minimize between model predictions and data) is the negative correlation, which ignores differences in baseline and amplitude between model predictions and observed data. This means the data do not need to be demeaned or converted to percent signal change first, but also that `baseline` and `amplitude` cannot be estimated by the grid search itself. We fix them here and estimate them with least squares in the next step.
 
 ```{code-cell} ipython3
 from prfmodel.fitters import GridFitter

--- a/docs/tutorials/examples/prf_2d_fmri_visual.md
+++ b/docs/tutorials/examples/prf_2d_fmri_visual.md
@@ -455,7 +455,7 @@ grid search will evaluate all possible combinations of these values and return t
 data best. This will result in a grid containing $20 ^ 3 = 8000$ parameter combinations. This is still a relatively small grid and we recommend specifying finer grids in practice.
 
 Let's construct the {py:class}`prfmodel.fitters.grid.GridFitter` and perform the grid search. Note that we set `batch_size=20` to let the {py:class}`prfmodel.fitters.grid.GridFitter`
-evaluate 20 parameter combinations at the same time (which saves us some memory). By default, the `loss` (i.e., the metric to minimize between model predictions and data) is cosine similarity, which ignores differences in scale between model predictions and observed data.
+evaluate 20 parameter combinations at the same time (which saves us some memory). By default, the `loss` (i.e., the metric to minimize between model predictions and data) is the negative correlation, which ignores differences in baseline and amplitude between model predictions and observed data. This means the data do not need to be demeaned or converted to percent signal change first, but also that `baseline` and `amplitude` cannot be estimated by the grid search itself. We fix them here and estimate them with least squares in the next step.
 
 ```{code-cell} ipython3
 from prfmodel.fitters import GridFitter

--- a/docs/tutorials/tutorials/div_norm_prf_simulated.md
+++ b/docs/tutorials/tutorials/div_norm_prf_simulated.md
@@ -188,8 +188,7 @@ param_ranges_gaussian = {
 ```
 
 For all three parameters, we defined ranges of 10 values, giving the fitter $10 \times 10 \times 10 = 1000$
-parameter combinations to evaluate. Let's construct the `GridFitter` and run the grid search. By default, the
-`GridFitter` uses a cosine similarity loss function that ignores differences in scale between model predictions and data.
+parameter combinations to evaluate. Let's construct the `GridFitter` and run the grid search.
 
 ```{code-cell} ipython3
 from prfmodel.fitters import GridFitter

--- a/docs/tutorials/tutorials/regressors.md
+++ b/docs/tutorials/tutorials/regressors.md
@@ -145,8 +145,8 @@ fig.legend();
 We can see that the predicted neural response contains some "noise" coming from the two regressors.
 
 Our next goal is to fit the model back to its own predicted neural timecourse. We first use a grid search to optimize
-the center and size of the Gaussian pRF (i.e., `mu_x`, `mu_y`, `sigma`). By default, the `GridFitter` uses a cosine
-similarity loss function that ignores differences in scale between model predictions and data.
+the center and size of the Gaussian pRF (i.e., `mu_x`, `mu_y`, `sigma`). By default, the `GridFitter` uses a
+correlation loss function that ignores differences in baseline and amplitude between model predictions and data.
 
 ```{code-cell} ipython3
 from prfmodel.fitters import GridFitter

--- a/src/prfmodel/fitters/__init__.py
+++ b/src/prfmodel/fitters/__init__.py
@@ -13,6 +13,10 @@ Each fitting method returns a history object that stores final loss scores for a
 The :mod:`~prfmodel.fitters.adapter` submodule contains functionality to transform parameters during model fitting
 (e.g., to optimize a parameter on the log scale). Currently, this is only implemented for SGD.
 
+The :mod:`~prfmodel.fitters.losses` submodule contains additional loss functions, such as
+:class:`~prfmodel.fitters.losses.CorrelationLoss`, which is the default loss of
+:class:`~prfmodel.fitters.GridFitter`.
+
 """
 
 from ._grid import GridFitter

--- a/src/prfmodel/fitters/_grid.py
+++ b/src/prfmodel/fitters/_grid.py
@@ -11,6 +11,7 @@ from keras import ops
 from more_itertools import chunked
 from tqdm.auto import tqdm
 from prfmodel._docstring import doc
+from prfmodel.fitters.losses import CorrelationLoss
 from prfmodel.models.base import BaseCanonical
 from prfmodel.stimuli import Stimulus
 from prfmodel.typing import Tensor
@@ -49,16 +50,26 @@ class GridFitter:
     %(model_fitter)s
     %(stimulus)s
     loss : keras.optimizers.Loss or Callable, optional
-        Loss instance or function with the signature `f(y, y_pred)`, where `y` is the target data and `y_pred` are the
-        model predicitons. Default is `None` where a `keras.losses.CosineSimilarity` loss is used. Note that, when
-        a `keras.losses.Loss` instance is used, the argument `reduction` must be set to `"none"` to enable loss
-        computation for all data batches.
+        Loss instance or function with the signature `f(y_true, y_pred)`, where `y_true` is the target data and
+        `y_pred` are the model predicitons. Default is `None` where a
+        :class:`~prfmodel.fitters.losses.CorrelationLoss` loss is used. Note that, when a
+        :class:`keras.losses.Loss` instance is used, the argument `reduction` must be set to `"none"` to enable
+        loss computation for all data batches. When a function is used, it must return a loss value for every unit in
+        `y_true` and `y_pred`.
     %(dtype)s
 
     Notes
     -----
     Depending on the size of the parameter grid and the number of batches in the data, the search can be very
     memory-intensive. For this reason, the grid is first split into batches that are evaluated iteratively.
+
+    The default :class:`~prfmodel.fitters.losses.CorrelationLoss` is invariant to the baseline and amplitude of the
+    prediction, so the target data does not need to be demeaned or converted to percent signal change beforehand.
+    The flip side is that parameters which only shift or scale the prediction (typically `baseline` and `amplitude`)
+    are not identifiable: all their grid values yield the same loss, and the returned estimate is an arbitrary one
+    among them. Fix such parameters to a single placeholder value in the grid and estimate them afterwards with
+    :class:`~prfmodel.fitters.LeastSquaresFitter`, or pass a loss that is sensitive to scale (e.g.,
+    :class:`keras.losses.MeanSquaredError`) if they must be estimated by the grid search itself.
 
     Examples
     --------
@@ -99,7 +110,7 @@ class GridFitter:
         self.stimulus = stimulus
 
         if loss is None:
-            loss = keras.losses.CosineSimilarity(reduction="none")
+            loss = CorrelationLoss(reduction="none")
 
         self.loss = loss
         self.dtype = dtype

--- a/src/prfmodel/fitters/losses.py
+++ b/src/prfmodel/fitters/losses.py
@@ -1,0 +1,53 @@
+"""Custom loss functions.
+
+Contains additional loss functions that inherit from `keras.losses.Loss`. They can be used inside
+:class:`~prfmodel.fitters.GridFitter` and :class:`~prfmodel.fitters.SGDFitter`.
+
+"""
+
+from keras import ops
+from keras.losses import Loss
+from keras.losses import cosine_similarity
+from prfmodel.typing import Tensor
+
+
+class CorrelationLoss(Loss):
+    """Correlation loss.
+
+    Computes the negative Pearson correlation coefficient loss. This loss is agnostic to differences in baseline and
+    amplitude between true values and predictions. This makes it particularly useful for
+    :class:`~prfmodel.fitters.GridFitter` where it is the default loss.
+
+    Inherits all arguments from :class:`keras.losses.Loss`.
+
+    Notes
+    -----
+    Computes the loss by first subtracting the mean from true values and predictions and then computing their
+    cosine similarity. Different from the usual definition of the Pearson correlation coefficient, the loss is zero
+    when either ``y_true`` or ``y_pred`` are constant (instead of ``NaN``).
+
+    Because the loss is invariant to baseline and amplitude, parameters that only shift or scale the prediction
+    are not identifiable under it. See the notes of :class:`~prfmodel.fitters.GridFitter` for the consequences.
+
+    """
+
+    def call(self, y_true: Tensor, y_pred: Tensor) -> Tensor:
+        """Compute the loss.
+
+        Parameters
+        ----------
+        y_true : :data:`prfmodel.typing.Tensor`
+            Tensor of true targets.
+        y_pred : :data:`prfmodel.typing.Tensor`
+            Tensor of predicted targets.
+
+        Returns
+        -------
+        :data:`prfmodel.typing.Tensor`
+            Correlation loss. Shape depends on the :attr:`reduction` argument in the class constructor.
+
+        """
+        return cosine_similarity(
+            y_true - ops.mean(y_true, axis=-1, keepdims=True),
+            y_pred - ops.mean(y_pred, axis=-1, keepdims=True),
+        )

--- a/tests/fitters/test_grid.py
+++ b/tests/fitters/test_grid.py
@@ -7,6 +7,7 @@ import pytest
 from prfmodel.fitters import GridFitter
 from prfmodel.fitters import GridHistory
 from prfmodel.fitters._grid import InfiniteLossWarning
+from prfmodel.fitters.losses import CorrelationLoss
 from prfmodel.models.prf import Gaussian2DPRFModel
 from prfmodel.stimuli import PRFStimulus
 from tests.conftest import TestSetup
@@ -23,10 +24,10 @@ class TestGridFitter(TestSetup):
         assert isinstance(history.history, dict)
         assert isinstance(history.history["loss"], np.ndarray)
 
-    def _check_grid_params(self, result_params: pd.DataFrame, params: pd.DataFrame) -> None:
+    def _check_grid_params(self, result_params: pd.DataFrame, params: pd.DataFrame, check_params: list[str]) -> None:
         assert isinstance(result_params, pd.DataFrame)
         assert result_params.shape == params.shape
-        assert np.allclose(result_params, params, equal_nan=True)
+        assert np.allclose(result_params[check_params], params[check_params], equal_nan=True)
 
     @pytest.fixture
     def param_ranges(self):
@@ -52,8 +53,14 @@ class TestGridFitter(TestSetup):
     @parametrize_dtype
     @parametrize_impulse_model
     @pytest.mark.parametrize(
-        "loss",
-        [None, keras.losses.CosineSimilarity(reduction="none")],
+        ("loss", "check_params"),
+        [
+            # Correlation loss (default) ignores differences in baseline and amplitude
+            (None, ["mu_x", "mu_y", "sigma"]),
+            (CorrelationLoss(reduction="none"), ["mu_x", "mu_y", "sigma"]),
+            # MSE is sensitive to baseline and amplitude
+            (keras.losses.MeanSquaredError(reduction="none"), ["mu_x", "mu_y", "sigma", "baseline", "amplitude"]),
+        ],
     )
     def test_fit(  # noqa: PLR0913 (too many arguments in function definition)
         self,
@@ -62,6 +69,7 @@ class TestGridFitter(TestSetup):
         loss: keras.losses.Loss,
         params: pd.DataFrame,
         param_ranges: dict[str, np.ndarray],
+        check_params: list[str],
         dtype: str,
     ):
         """Test that the grid search recovers the parameters an independent model generated data from.
@@ -88,7 +96,32 @@ class TestGridFitter(TestSetup):
         history, grid_params = fitter.fit(observed, param_ranges, batch_size=20)
 
         self._check_history(history)
-        self._check_grid_params(grid_params, params)
+        self._check_grid_params(grid_params, params, check_params)
+
+    def test_fit_default_loss_is_offset_invariant(
+        self,
+        stimulus: PRFStimulus,
+        model: Gaussian2DPRFModel,
+        params: pd.DataFrame,
+        param_ranges: dict[str, np.ndarray],
+    ):
+        """Test that the default loss recovers the pRF from data with a baseline that is absent from the grid."""
+        fitter = GridFitter(
+            model=model,
+            stimulus=stimulus,
+        )
+
+        shifted_params = params.copy()
+        shifted_params["baseline"] += 10.0
+        observed = model(stimulus, shifted_params)
+
+        # The data baseline is far outside the grid, which only offers baselines close to zero
+        offset_ranges = {**param_ranges, "baseline": [0.0]}
+
+        history, grid_params = fitter.fit(observed, offset_ranges, batch_size=20)
+
+        self._check_history(history)
+        self._check_grid_params(grid_params, params, ["mu_x", "mu_y", "sigma"])
 
     def test_fit_infinite_loss_warning(
         self,
@@ -113,4 +146,4 @@ class TestGridFitter(TestSetup):
             history, grid_params = fitter.fit(observed, param_ranges, batch_size=20)
 
         self._check_history(history)
-        self._check_grid_params(grid_params, params_copy)
+        self._check_grid_params(grid_params, params_copy, ["mu_x", "mu_y", "sigma"])

--- a/tests/fitters/test_losses.py
+++ b/tests/fitters/test_losses.py
@@ -1,0 +1,81 @@
+"""Tests for custom loss functions."""
+
+import numpy as np
+import pytest
+from prfmodel.fitters.losses import CorrelationLoss
+
+
+class TestCorrelationLoss:
+    """Tests for the CorrelationLoss class."""
+
+    num_units = 10
+    num_frames = 5
+
+    @pytest.fixture
+    def loss(self) -> CorrelationLoss:
+        """Create a loss instance."""
+        return CorrelationLoss()
+
+    def test_perfect_correlation(self, loss: CorrelationLoss):
+        """Test that two identical signals are perfectly positively correlated."""
+        y_true = np.linspace(-5.0, 5.0, self.num_units)
+        y_pred = np.copy(y_true)
+
+        assert np.isclose(loss(y_true, y_pred), -1.0)  # loss is negative correlation
+
+    def test_perfect_inverse_correlation(self, loss: CorrelationLoss):
+        """Test that two flipped signals are perfectly negatively correlated."""
+        y_true = np.linspace(-5.0, 5.0, self.num_units)
+        y_pred = np.flip(np.copy(y_true))
+
+        assert np.isclose(loss(y_true, y_pred), 1.0)
+
+    def test_random_matches_pearson_correlation(self, loss: CorrelationLoss):
+        """Test that the loss of two random signals is the negative of their Pearson correlation."""
+        rng = np.random.default_rng(2026)
+        y_true = rng.random(self.num_units)
+        y_pred = rng.random(self.num_units)
+
+        loss_val = loss(y_true, y_pred)
+
+        assert np.isclose(loss_val, -np.corrcoef(y_true, y_pred)[0, 1], atol=1e-6)
+
+    def test_zero_variance_no_correlation(self, loss: CorrelationLoss):
+        """Test that two signals with zero variance are not correlated."""
+        y_true = np.ones((self.num_units,))
+        y_pred = np.copy(y_true)
+
+        assert np.isclose(loss(y_true, y_pred), 0.0)
+
+    def test_baseline_shift(self, loss: CorrelationLoss):
+        """Test that two baseline-shifted signals are perfectly positively correlated."""
+        y_true = np.linspace(-5.0, 5.0, self.num_units)
+        y_pred = np.copy(y_true) + 10
+
+        assert np.isclose(loss(y_true, y_pred), -1.0)
+
+    def test_amplitude_scaling(self, loss: CorrelationLoss):
+        """Test that two amplitude-scaled signals are perfectly positively correlated."""
+        y_true = np.linspace(-5.0, 5.0, self.num_units)
+        y_pred = np.copy(y_true) * 10
+
+        assert np.isclose(loss(y_true, y_pred), -1.0)
+
+    def test_batching_with_reduction(self, loss: CorrelationLoss):
+        """Test that reduction returns a single loss value for a batch."""
+        y_true = np.ones((self.num_units, self.num_frames))
+        y_pred = np.copy(y_true)
+
+        loss_val = loss(y_true, y_pred)
+
+        assert loss_val.shape == ()
+
+    def test_batching_without_reduction(self):
+        """Test that no reduction returns a loss value for each unit in a batch."""
+        loss = CorrelationLoss(reduction="none")
+        y_true = np.ones((self.num_units, self.num_frames))
+        y_pred = np.copy(y_true)
+
+        loss_arr = loss(y_true, y_pred)
+
+        assert loss_arr.shape == (self.num_units,)


### PR DESCRIPTION
Adds a `prfmodel.fitters.losses.CorrelationLoss` class that computes the Pearson correlation coefficient as a loss function.

This is the new default loss for `GridFitter` because it ignores differences in amplitude *and* baseline. Previously, the cosine similarity loss only ignored differences in amplitude but was sensitive to differences in baseline.